### PR TITLE
use weather-icons css instead of sass

### DIFF
--- a/WeatherIcons.vue
+++ b/WeatherIcons.vue
@@ -9,8 +9,8 @@
 </template>
 
 <script>
-import "weathericons/sass/weather-icons.scss";
-import "weathericons/sass/weather-icons-wind.scss";
+import "weathericons/css/weather-icons.css";
+import "weathericons/css/weather-icons-wind.css";
 
 export default {
   props: {


### PR DESCRIPTION
sass files need a special `sass-loader`, it's safer to require the css files so it can be used in projects which don't have sass-loader configured.